### PR TITLE
Fix sidebar category reorder drag

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -51,7 +51,7 @@ export function AppShell() {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 8, // 8px movement required to start dragging
+        distance: 3, // 3px movement required to start dragging
       },
     }),
     useSensor(KeyboardSensor, {
@@ -63,18 +63,14 @@ export function AppShell() {
     const { active, over } = event
     if (!over || active.id === over.id) return
 
-    console.log('Drag ended:', { active: active.id, over: over.id, overData: over.data?.current, activeData: active.data?.current })
-
     // Check if dropping on a category (sidebar)
     if (over.data?.current?.type === 'category') {
-      console.log('Moving prompt to category:', over.id)
       await store.movePrompt(active.id, over.id)
       return
     }
 
     // Check if dropping on uncategorized area
     if (over.id === 'uncategorized') {
-      console.log('Uncategorizing prompt')
       await store.movePrompt(active.id, '')
       return
     }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -26,8 +26,26 @@ function CategoryRow({ category, onRename, onDelete, isOver, isActive }) {
       <div className={`transition-opacity duration-150 ml-2 flex items-center gap-1 ${
         isOver ? 'opacity-0' : 'opacity-0 group-hover:opacity-100'
       }`}>
-        <button aria-label="Rename" onClick={() => onRename(category)} className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-800"><Pencil size={14} /></button>
-        <button aria-label="Delete" onClick={() => onDelete(category)} className="p-1 rounded hover:bg-red-100 text-red-600 dark:hover:bg-red-900/30"><Trash2 size={14} /></button>
+        <button 
+          aria-label="Rename" 
+          onClick={(e) => {
+            e.stopPropagation()
+            onRename(category)
+          }} 
+          className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-800"
+        >
+          <Pencil size={14} />
+        </button>
+        <button 
+          aria-label="Delete" 
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete(category)
+          }} 
+          className="p-1 rounded hover:bg-red-100 text-red-600 dark:hover:bg-red-900/30"
+        >
+          <Trash2 size={14} />
+        </button>
       </div>
     </div>
   )
@@ -58,13 +76,15 @@ function SortableCategory({ id, category, onRename, onDelete }) {
   const style = { transform: CSS.Transform.toString(transform), transition }
 
   return (
-    <div ref={setRefs} style={style} {...attributes} className="flex items-center gap-2 w-full">
-      <div 
-        className="cursor-grab hover:cursor-grabbing touch-none flex-shrink-0" 
-        {...listeners} 
-        style={{ touchAction: 'none' }}
-        title="Drag to reorder"
-      >
+    <div 
+      ref={setRefs} 
+      style={{ ...style, touchAction: 'none' }} 
+      {...attributes} 
+      {...listeners}
+      className="flex items-center gap-2 w-full cursor-grab hover:cursor-grabbing"
+      title="Drag to reorder"
+    >
+      <div className="flex-shrink-0">
         <svg width="12" height="12" viewBox="0 0 16 16" className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300">
           <circle cx="3" cy="6" r="1" fill="currentColor" />
           <circle cx="3" cy="10" r="1" fill="currentColor" />


### PR DESCRIPTION
Fix drag-to-reorder functionality for categories in the sidebar.

The drag operation was previously hindered by an incorrect drag handle implementation, event interference from nested buttons, and an overly restrictive drag activation distance. This PR resolves these issues by applying drag listeners to the entire category row, stopping event propagation on action buttons, and reducing the drag activation threshold.

---
<a href="https://cursor.com/background-agent?bcId=bc-67359217-ef63-41b8-964f-925d5eff0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67359217-ef63-41b8-964f-925d5eff0656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

